### PR TITLE
Allow to pass user instead of email address (revised)

### DIFF
--- a/django_gravatar/templatetags/gravatar.py
+++ b/django_gravatar/templatetags/gravatar.py
@@ -5,12 +5,22 @@ from django_gravatar.helpers import get_gravatar_url, has_gravatar as has_gravat
 # Get template.Library instance
 register = template.Library()
 
-def gravatar_url(email, size=GRAVATAR_DEFAULT_SIZE):
-    """ Builds a gravatar url from an email """
+def gravatar_url(user_or_email, size=GRAVATAR_DEFAULT_SIZE):
+    """ Builds a gravatar url from an user or email """
+    if hasattr(user_or_email, 'email'):
+        email = user_or_email.email
+    else:
+        email = user_or_email
+
     return get_gravatar_url(email=email, size=size)
 
-def gravatar(email, size=GRAVATAR_DEFAULT_SIZE, alt_text='', css_class='gravatar'):
-    """ Builds an gravatar <img> tag from an email """
+def gravatar(user_or_email, size=GRAVATAR_DEFAULT_SIZE, alt_text='', css_class='gravatar'):
+    """ Builds an gravatar <img> tag from an user or email """
+    if hasattr(user_or_email, 'email'):
+        email = user_or_email.email
+    else:
+        email = user_or_email
+    
     url = get_gravatar_url(email=email, size=size)
 
     return '<img class="{css_class}" src="{src}" width="{width}" height="{height}" alt="{alt}" />'.format(\

--- a/django_gravatar/tests.py
+++ b/django_gravatar/tests.py
@@ -100,3 +100,27 @@ class TestGravatarTemplateTags(TestCase):
         self.assertTrue('height="%s"' % (size,) in rendered)
         self.assertTrue('alt="%s"' % (alt_text,) in rendered)
         self.assertTrue('class="%s"' % (css_class,) in rendered)
+
+    def test_gravatar_user_url(self):
+        # class with email attribute
+        class user:
+            email = 'bouke@webatoom.nl'
+
+        context = Context({'user': user})
+
+        t = Template("{% load gravatar %}{% gravatar_url user %}")
+        rendered = t.render(context)
+
+        self.assertEqual(rendered, get_gravatar_url(user.email))
+
+    def test_gravatar_user_img(self):
+        # class with email attribute
+        class user:
+            email = 'bouke@webatoom.nl'
+        
+        context = Context({'user': user})
+
+        t = Template("{% load gravatar %}{% gravatar user %}")
+        rendered = t.render(context)
+
+        self.assertTrue(get_gravatar_url(user.email) in rendered)


### PR DESCRIPTION
You asked to update the patch to include a testcase and move the logic to the templatetag. Please have a look at this patch; it should cover those two areas. Great work on the library, thanks!
