### PR TITLE
When passing invalid input, should fail silently

### DIFF
--- a/django_gravatar/templatetags/gravatar.py
+++ b/django_gravatar/templatetags/gravatar.py
@@ -12,7 +12,10 @@ def gravatar_url(user_or_email, size=GRAVATAR_DEFAULT_SIZE):
     else:
         email = user_or_email
 
-    return get_gravatar_url(email=email, size=size)
+    try:
+        return get_gravatar_url(email=email, size=size)
+    except:
+        return ''
 
 def gravatar(user_or_email, size=GRAVATAR_DEFAULT_SIZE, alt_text='', css_class='gravatar'):
     """ Builds an gravatar <img> tag from an user or email """
@@ -20,8 +23,11 @@ def gravatar(user_or_email, size=GRAVATAR_DEFAULT_SIZE, alt_text='', css_class='
         email = user_or_email.email
     else:
         email = user_or_email
-    
-    url = get_gravatar_url(email=email, size=size)
+
+    try:
+        url = get_gravatar_url(email=email, size=size)
+    except:
+        return ''
 
     return '<img class="{css_class}" src="{src}" width="{width}" height="{height}" alt="{alt}" />'.format(\
         css_class=css_class, src=url, width=size, height=size, alt=alt_text)

--- a/django_gravatar/tests.py
+++ b/django_gravatar/tests.py
@@ -124,3 +124,11 @@ class TestGravatarTemplateTags(TestCase):
         rendered = t.render(context)
 
         self.assertTrue(get_gravatar_url(user.email) in rendered)
+
+    def test_invalid_input(self):
+        context = Context({'email': None})
+
+        t = Template("{% load gravatar %}{% gravatar email %}")
+        rendered = t.render(context)
+
+        self.assertEqual("", rendered, "Invalid input should return empty result")


### PR DESCRIPTION
From the [django manual](https://docs.djangoproject.com/en/dev/howto/custom-template-tags/#writing-the-renderer):

> render() should never raise TemplateSyntaxError or any other exception. It should fail silently, just as template filters should.

Added a test which fails if the passed variable evaluates to `None` (or anything the helper chokes upon). I had a problem with an optional foreignkey and didn't like the foresight of creating `if`-conditions all over the place.
