### PR TITLE
'.jpg' suffix is unnecessary

### DIFF
--- a/django_gravatar/helpers.py
+++ b/django_gravatar/helpers.py
@@ -56,7 +56,7 @@ def get_gravatar_url(email, size=GRAVATAR_DEFAULT_SIZE, default=GRAVATAR_DEFAULT
     })
 
     # Build url
-    url = '{base}avatar/{hash}.jpg?{qs}'.format(base=url_base,
+    url = '{base}avatar/{hash}?{qs}'.format(base=url_base,
             hash=email_hash, qs=query_string)
 
     return url


### PR DESCRIPTION
Not all avatars are formatted as  ".jpg" . For example, follow url will be failed:

http://gravatar.com/avatar/908e0b099a9d0a625740701559639b83.jpg?s=80&r=g&d=mm

But it works without ".jpg" suffix:

http://gravatar.com/avatar/908e0b099a9d0a625740701559639b83?s=80&r=g&d=mm

According to [Gravatar's documentation](http://en.gravatar.com/site/implement/images/), '.jpg' suffix may be unnecessary for WEB APPs.
