### PR TITLE
Add instructions for running the tests to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,4 +97,11 @@ Feel free to `fork django-gravatar <https://github.com/twaddington/django-gravat
 on GitHub! We'd love to see your pull requests. Please make sure you run
 tests before submitting a patch.
 
+Run tests:
+
+::
+
+    $> cd example_projects
+    $> ./manage.py test django_gravatar
+
 .. _Gittip donation: https://www.gittip.com/twaddington/ 


### PR DESCRIPTION
It's convenient for developers trying to contribute to have clear
instructions on how to run the test suite. This is probably obvious for seasoned
django developers, but for newer developers, adding these instructions to the
README may save them some time.