### PR TITLE
Escape the return value of gravatar_profile_url()

### DIFF
--- a/django_gravatar/templatetags/gravatar.py
+++ b/django_gravatar/templatetags/gravatar.py
@@ -48,7 +48,7 @@ def gravatar_profile_url(user_or_email):
         email = user_or_email
 
     try:
-        return get_gravatar_profile_url(email)
+        return escape(get_gravatar_profile_url(email))
     except:
         return ''
 


### PR DESCRIPTION
The gravatar_url() function escapes the return value of get_gravatar_url(). gravatar_profile_url() should also escape the return value of get_gravatar_profile_url().
  
