### PR TITLE
make example_project only available in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README
 include README.rst
 include LICENSE
+include example_project/*

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author='Tristan Waddington',
     author_email='tristan.waddington@gmail.com',
     url='https://github.com/twaddington/django-gravatar',
-    packages=['django_gravatar', 'django_gravatar.templatetags', 'example_project'],
+    packages=['django_gravatar', 'django_gravatar.templatetags'],
     classifiers=[
         'Development Status :: 5 - Production/Stable', # 4 Beta, 5 Production/Stable
         'Environment :: Web Environment',


### PR DESCRIPTION
setup.py: Removing example_project as module and adding it to MANIFEST.in.
Fixes #35. 