### PR TITLE
More complete options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ MANIFEST
 dist/
 build/
 .tox
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+default_language_version:
+    python: python3.10
+repos:
+    - repo: https://github.com/asottile/pyupgrade
+      rev: v2.38.0
+      hooks:
+          - id: pyupgrade
+            args:
+                [
+                    "--py36-plus",
+                    "--py37-plus",
+                    "--py38-plus",
+                    "--py39-plus",
+                    "--py310-plus",
+                ]
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.3.0
+      hooks:
+          # See https://pre-commit.com/hooks.html for more hooks
+          - id: check-ast
+          - id: check-case-conflict
+          - id: check-executables-have-shebangs
+          - id: check-merge-conflict
+          - id: debug-statements
+          - id: end-of-file-fixer
+          - id: name-tests-test
+            args: ["--django"]
+          - id: trailing-whitespace
+          - id: detect-private-key
+          # - id: requirements-txt-fixer
+    - repo: https://github.com/psf/black
+      rev: 22.10.0
+      hooks:
+          - id: black
+    - repo: https://github.com/pycqa/isort
+      rev: 5.10.1
+      hooks:
+          - id: isort
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 5.0.4
+      hooks:
+          - id: flake8
+            additional_dependencies:
+                [
+                    "flake8-bugbear",
+                    "flake8-comprehensions",
+                    "flake8-mutable",
+                    "flake8-print",
+                    "flake8-simplify",
+                ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
+  - "3.10"
 
 env:
   - DJANGO_VERSION=2.2.9
   - DJANGO_VERSION=3.0.2
+  - DJANGO_VERSION=4.1.2
 
 install:
   - pip install -q Django==$DJANGO_VERSION

--- a/.vscode/.github/workflows/publish-to-pypi.yml
+++ b/.vscode/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,35 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Django: Test",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}\\example_project\\manage.py",
+            "args": [
+                "test",
+                "django_gravatar",
+            ],
+            "django": true,
+            "justMyCode": true
+        },
+    ]
+}

--- a/README.rst
+++ b/README.rst
@@ -76,17 +76,23 @@ Configuring
 -----------
 The following options can be configured in your settings.py:
 
-GRAVATAR_URL            # Gravatar base url. Defaults to 'http://www.gravatar.com/'
+GRAVATAR_URL             # Gravatar base url. Defaults to 'http://www.gravatar.com/'
 
-GRAVATAR_SECURE_URL     # Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/'
+GRAVATAR_SECURE_URL      # Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/'
 
-GRAVATAR_DEFAULT_SIZE   # Gravatar size in pixels. Defaults to '80'
+GRAVATAR_AGNOSTICT_URL   # Gravatar base url. Defaults to '//www.gravatar.com'.
+Uses 'https' on 'https' websites, 'http' otherwise.
 
-GRAVATAR_DEFAULT_IMAGE  # An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm'
+GRAVATAR_DEFAULT_SIZE    # Gravatar size in pixels. Defaults to '80'
 
-GRAVATAR_DEFAULT_RATING # One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'
+GRAVATAR_DEFAULT_IMAGE   # An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm'
 
-GRAVATAR_DEFAULT_SECURE # True to use https by default, False for plain http. Defaults to True
+GRAVATAR_DEFAULT_RATING  # One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'
+
+GRAVATAR_DEFAULT_SECURE  # True to use https by default, False for plain http.
+None for agnostic. Defaults to None
+
+GRAVATAR_FORCE_EXTENSION # Adds '.jpg' to file
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -91,9 +91,9 @@ The following options can be configured in your settings.py:
 +--------------------------+------------------------------------------------------------------------------------------------------------+
 | GRAVATAR_DEFAULT_RATING  | One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'                                                 |
 +--------------------------+------------------------------------------------------------------------------------------------------------+
-| GRAVATAR_DEFAULT_SECURE  | True to use https by default, False for plain http. None for agnostic. Defaults to None                    |
+| GRAVATAR_DEFAULT_SECURE  | `True` to use https by default, `False` for plain http. `None` for agnostic. Defaults to `None`            |
 +--------------------------+------------------------------------------------------------------------------------------------------------+
-| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file. Defaults to False (no '.jpg')                                                         |
+| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file. Defaults to `False` (no '.jpg')                                                       |
 +--------------------------+------------------------------------------------------------------------------------------------------------+
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ The following options can be configured in your settings.py:
 +--------------------------+------------------------------------------------------------------------------------------------------------+
 | GRAVATAR_DEFAULT_SECURE  | True to use https by default, False for plain http. None for agnostic. Defaults to None                    |
 +--------------------------+------------------------------------------------------------------------------------------------------------+
-| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file.                                                                                       |
+| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file. Defaults to False (no '.jpg')                                                         |
 +--------------------------+------------------------------------------------------------------------------------------------------------+
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -76,28 +76,25 @@ Configuring
 -----------
 The following options can be configured in your settings.py:
 
-+--------------------------+----------------------------------------------------------------------------+
-| Setting Name             | Description                                                                |
-+==========================+============================================================================+
-| GRAVATAR_URL             | Gravatar base url. Defaults to 'http://www.gravatar.com/'                  |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_SECURE_URL      | Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/' |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_AGNOSTIC_URL    | Gravatar base url. Defaults to '//www.gravatar.com'.                       |
-|                          | Uses 'https' on 'https' websites, 'http' otherwise.                        |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_DEFAULT_SIZE    | Gravatar size in pixels. Defaults to '80'                                  |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_DEFAULT_IMAGE   | An image url or one of the following: 'mm', 'identicon', 'monsterid',      |
-|                          | 'wavatar', 'retro'. Defaults to 'mm'                                       |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_DEFAULT_RATING  | One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'                 |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_DEFAULT_SECURE  | True to use https by default, False for plain http. None for agnostic.     |
-|                          | Defaults to None                                                           |
-+--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file.                                                       |
-+--------------------------+----------------------------------------------------------------------------+
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| Setting Name             | Description                                                                                                |
++==========================+============================================================================================================+
+| GRAVATAR_URL             | Gravatar base url. Defaults to 'http://www.gravatar.com/'                                                  |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_SECURE_URL      | Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/'                                 |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_AGNOSTIC_URL    | Gravatar base url. Defaults to '//www.gravatar.com'. Uses 'https' on 'https' websites, 'http' otherwise.   |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_SIZE    | Gravatar size in pixels. Defaults to '80'                                                                  |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_IMAGE   | An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm' |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_RATING  | One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'                                                 |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_SECURE  | True to use https by default, False for plain http. None for agnostic. Defaults to None                    |
++--------------------------+------------------------------------------------------------------------------------------------------------+
+| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file.                                                                                       |
++--------------------------+------------------------------------------------------------------------------------------------------------+
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -83,12 +83,12 @@ The following options can be configured in your settings.py:
 +--------------------------+----------------------------------------------------------------------------+
 | GRAVATAR_SECURE_URL      | Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/' |
 +--------------------------+----------------------------------------------------------------------------+
-| GRAVATAR_AGNOSTICT_URL   | Gravatar base url. Defaults to '//www.gravatar.com'.                       |
+| GRAVATAR_AGNOSTIC_URL    | Gravatar base url. Defaults to '//www.gravatar.com'.                       |
 |                          | Uses 'https' on 'https' websites, 'http' otherwise.                        |
 +--------------------------+----------------------------------------------------------------------------+
 | GRAVATAR_DEFAULT_SIZE    | Gravatar size in pixels. Defaults to '80'                                  |
 +--------------------------+----------------------------------------------------------------------------+
-|GRAVATAR_DEFAULT_IMAGE    | An image url or one of the following: 'mm', 'identicon', 'monsterid',      |
+| GRAVATAR_DEFAULT_IMAGE   | An image url or one of the following: 'mm', 'identicon', 'monsterid',      |
 |                          | 'wavatar', 'retro'. Defaults to 'mm'                                       |
 +--------------------------+----------------------------------------------------------------------------+
 | GRAVATAR_DEFAULT_RATING  | One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'                 |

--- a/README.rst
+++ b/README.rst
@@ -76,23 +76,28 @@ Configuring
 -----------
 The following options can be configured in your settings.py:
 
-GRAVATAR_URL             # Gravatar base url. Defaults to 'http://www.gravatar.com/'
-
-GRAVATAR_SECURE_URL      # Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/'
-
-GRAVATAR_AGNOSTICT_URL   # Gravatar base url. Defaults to '//www.gravatar.com'.
-Uses 'https' on 'https' websites, 'http' otherwise.
-
-GRAVATAR_DEFAULT_SIZE    # Gravatar size in pixels. Defaults to '80'
-
-GRAVATAR_DEFAULT_IMAGE   # An image url or one of the following: 'mm', 'identicon', 'monsterid', 'wavatar', 'retro'. Defaults to 'mm'
-
-GRAVATAR_DEFAULT_RATING  # One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'
-
-GRAVATAR_DEFAULT_SECURE  # True to use https by default, False for plain http.
-None for agnostic. Defaults to None
-
-GRAVATAR_FORCE_EXTENSION # Adds '.jpg' to file
++--------------------------+----------------------------------------------------------------------------+
+| Setting Name             | Description                                                                |
++==========================+============================================================================+
+| GRAVATAR_URL             | Gravatar base url. Defaults to 'http://www.gravatar.com/'                  |
++--------------------------+----------------------------------------------------------------------------+
+| GRAVATAR_SECURE_URL      | Gravatar base secure https url. Defaults to 'https://secure.gravatar.com/' |
++--------------------------+----------------------------------------------------------------------------+
+| GRAVATAR_AGNOSTICT_URL   | Gravatar base url. Defaults to '//www.gravatar.com'.                       |
+|                          | Uses 'https' on 'https' websites, 'http' otherwise.                        |
++--------------------------+----------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_SIZE    | Gravatar size in pixels. Defaults to '80'                                  |
++--------------------------+----------------------------------------------------------------------------+
+|GRAVATAR_DEFAULT_IMAGE    | An image url or one of the following: 'mm', 'identicon', 'monsterid',      |
+|                          | 'wavatar', 'retro'. Defaults to 'mm'                                       |
++--------------------------+----------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_RATING  | One of the following: 'g', 'pg', 'r', 'x'. Defaults to 'g'                 |
++--------------------------+----------------------------------------------------------------------------+
+| GRAVATAR_DEFAULT_SECURE  | True to use https by default, False for plain http. None for agnostic.     |
+|                          | Defaults to None                                                           |
++--------------------------+----------------------------------------------------------------------------+
+| GRAVATAR_FORCE_EXTENSION | Adds '.jpg' to file.                                                       |
++--------------------------+----------------------------------------------------------------------------+
 
 Contributing
 ------------

--- a/django_gravatar/compat.py
+++ b/django_gravatar/compat.py
@@ -1,24 +1,24 @@
 """
 This module provides compatibility with older versions of Django and Python
 """
-
 try:
-    from urllib.parse import urlparse, parse_qs, quote_plus, urlencode
-except ImportError:     # Python 2
-    from urlparse import urlparse, parse_qs
+    from urllib.parse import parse_qs, quote_plus, urlencode, urlparse
+except ImportError:  # Python 2
     from urllib import quote_plus, urlencode
+
+    from urlparse import parse_qs, urlparse
 
 try:
     from urllib.request import Request, urlopen
-except ImportError:     # Python 2
+except ImportError:  # Python 2
     from urllib2 import Request, urlopen
 
 try:
     from urllib.error import HTTPError
-except ImportError:     # Python 2
+except ImportError:  # Python 2
     from urllib2 import HTTPError
 
 try:
     from urllib.error import URLError
-except ImportError:     # Python 2
+except ImportError:  # Python 2
     from urllib2 import URLError

--- a/django_gravatar/helpers.py
+++ b/django_gravatar/helpers.py
@@ -2,44 +2,62 @@ import hashlib
 
 from django.conf import settings
 
-from .compat import urlencode, urlopen, Request, HTTPError, URLError
+from .compat import HTTPError, Request, URLError, urlencode, urlopen
+
+# This option controls whether a file extension is included
+GRAVATAR_FORCE_EXTENSION = getattr(settings, "GRAVATAR_FORCE_EXTENSION", False)
 
 # These options can be used to change the default image if no gravatar is found
-GRAVATAR_DEFAULT_IMAGE_404 = '404'
-GRAVATAR_DEFAULT_IMAGE_MYSTERY_MAN = 'mm'
-GRAVATAR_DEFAULT_IMAGE_IDENTICON = 'identicon'
-GRAVATAR_DEFAULT_IMAGE_MONSTER = 'monsterid'
-GRAVATAR_DEFAULT_IMAGE_WAVATAR = 'wavatar'
-GRAVATAR_DEFAULT_IMAGE_RETRO = 'retro'
+GRAVATAR_DEFAULT_IMAGE_404 = "404"
+GRAVATAR_DEFAULT_IMAGE_MYSTERY_MAN = "mm"
+GRAVATAR_DEFAULT_IMAGE_IDENTICON = "identicon"
+GRAVATAR_DEFAULT_IMAGE_MONSTER = "monsterid"
+GRAVATAR_DEFAULT_IMAGE_WAVATAR = "wavatar"
+GRAVATAR_DEFAULT_IMAGE_RETRO = "retro"
 
 # These options can be used to restrict gravatar content
-GRAVATAR_RATING_G = 'g'
-GRAVATAR_RATING_PG = 'pg'
-GRAVATAR_RATING_R = 'r'
-GRAVATAR_RATING_X = 'x'
+GRAVATAR_RATING_G = "g"
+GRAVATAR_RATING_PG = "pg"
+GRAVATAR_RATING_R = "r"
+GRAVATAR_RATING_X = "x"
 
 # Get Gravatar base url from settings.py
-GRAVATAR_URL = getattr(settings, 'GRAVATAR_URL', 'http://www.gravatar.com/')
-GRAVATAR_SECURE_URL = getattr(settings, 'GRAVATAR_SECURE_URL', 'https://secure.gravatar.com/')
+GRAVATAR_URL = getattr(settings, "GRAVATAR_URL", "http://www.gravatar.com/")
+GRAVATAR_SECURE_URL = getattr(
+    settings, "GRAVATAR_SECURE_URL", "https://secure.gravatar.com/"
+)
+GRAVATAR_AGNOSTIC_URL = getattr(
+    settings, "GRAVATAR_AGNOSTIC_URL", "//www.gravatar.com/"
+)
 
 # Get user defaults from settings.py
-GRAVATAR_DEFAULT_SIZE = getattr(settings, 'GRAVATAR_DEFAULT_SIZE', 80)
-GRAVATAR_DEFAULT_IMAGE = getattr(settings, 'GRAVATAR_DEFAULT_IMAGE',
-        GRAVATAR_DEFAULT_IMAGE_MYSTERY_MAN)
-GRAVATAR_DEFAULT_RATING = getattr(settings, 'GRAVATAR_DEFAULT_RATING',
-        GRAVATAR_RATING_G)
-GRAVATAR_DEFAULT_SECURE = getattr(settings, 'GRAVATAR_DEFAULT_SECURE', True)
+GRAVATAR_DEFAULT_SIZE = getattr(settings, "GRAVATAR_DEFAULT_SIZE", 80)
+GRAVATAR_DEFAULT_IMAGE = getattr(
+    settings, "GRAVATAR_DEFAULT_IMAGE", GRAVATAR_DEFAULT_IMAGE_MYSTERY_MAN
+)
+GRAVATAR_DEFAULT_RATING = getattr(
+    settings, "GRAVATAR_DEFAULT_RATING", GRAVATAR_RATING_G
+)
+GRAVATAR_DEFAULT_SECURE = getattr(settings, "GRAVATAR_DEFAULT_SECURE", None)
 
 
 def calculate_gravatar_hash(email):
     # Calculate the email hash
+    if len(email.strip()) == 0:
+        return "0000"
     enc_email = email.strip().lower().encode("utf-8")
     email_hash = hashlib.md5(enc_email).hexdigest()
     return email_hash
 
 
-def get_gravatar_url(email, size=GRAVATAR_DEFAULT_SIZE, default=GRAVATAR_DEFAULT_IMAGE,
-        rating=GRAVATAR_DEFAULT_RATING, secure=GRAVATAR_DEFAULT_SECURE):
+def get_gravatar_url(
+    email,
+    size=GRAVATAR_DEFAULT_SIZE,
+    extension: bool = GRAVATAR_FORCE_EXTENSION,
+    default=GRAVATAR_DEFAULT_IMAGE,
+    rating=GRAVATAR_DEFAULT_RATING,
+    secure=GRAVATAR_DEFAULT_SECURE,
+):
     """
     Builds a url to a gravatar from an email address.
 
@@ -51,22 +69,31 @@ def get_gravatar_url(email, size=GRAVATAR_DEFAULT_SIZE, default=GRAVATAR_DEFAULT
     """
     if secure:
         url_base = GRAVATAR_SECURE_URL
+    elif secure is None:
+        url_base = GRAVATAR_AGNOSTIC_URL
     else:
         url_base = GRAVATAR_URL
 
     # Calculate the email hash
     email_hash = calculate_gravatar_hash(email)
 
+    # Build extension string
+    if extension:
+        extension_string = ".jpg"
+    else:
+        extension_string = ""
+
     # Build querystring
-    query_string = urlencode({
-        's': str(size),
-        'd': default,
-        'r': rating,
-    })
+    query_string = urlencode(
+        {
+            "s": str(size),
+            "d": default,
+            "r": rating,
+        }
+    )
 
     # Build url
-    url = '{base}avatar/{hash}.jpg?{qs}'.format(base=url_base,
-            hash=email_hash, qs=query_string)
+    url = f"{url_base}avatar/{email_hash}{extension_string}?{query_string}"
 
     return url
 
@@ -81,8 +108,8 @@ def has_gravatar(email):
     # Verify an OK response was received
     try:
         request = Request(url)
-        request.get_method = lambda: 'HEAD'
-        return 200 == urlopen(request).code
+        request.get_method = lambda: "HEAD"
+        return urlopen(request).code == 200
     except (HTTPError, URLError):
         return False
 
@@ -103,6 +130,6 @@ def get_gravatar_profile_url(email, secure=GRAVATAR_DEFAULT_SECURE):
     email_hash = calculate_gravatar_hash(email)
 
     # Build url
-    url = '{base}{hash}'.format(base=url_base, hash=email_hash)
+    url = f"{url_base}{email_hash}"
 
     return url

--- a/django_gravatar/templatetags/gravatar.py
+++ b/django_gravatar/templatetags/gravatar.py
@@ -9,29 +9,31 @@ register = template.Library()
 
 
 def gravatar_url(user_or_email, size=GRAVATAR_DEFAULT_SIZE):
-    """ Builds a gravatar url from an user or email """
-    if hasattr(user_or_email, 'email'):
+    """Builds a gravatar url from an user or email"""
+    if hasattr(user_or_email, "email"):
         email = user_or_email.email
     else:
         email = user_or_email
 
     try:
         return escape(get_gravatar_url(email=email, size=size))
-    except:
-        return ''
+    except Exception:
+        return ""
 
 
-def gravatar(user_or_email, size=GRAVATAR_DEFAULT_SIZE, alt_text='', css_class='gravatar'):
-    """ Builds an gravatar <img> tag from an user or email """
-    if hasattr(user_or_email, 'email'):
+def gravatar(
+    user_or_email, size=GRAVATAR_DEFAULT_SIZE, alt_text="", css_class="gravatar"
+):
+    """Builds an gravatar <img> tag from an user or email"""
+    if hasattr(user_or_email, "email"):
         email = user_or_email.email
     else:
         email = user_or_email
 
     try:
         url = escape(get_gravatar_url(email=email, size=size))
-    except:
-        return ''
+    except Exception:
+        return ""
 
     return mark_safe(
         '<img class="{css_class}" src="{src}" width="{width}"'
@@ -42,15 +44,16 @@ def gravatar(user_or_email, size=GRAVATAR_DEFAULT_SIZE, alt_text='', css_class='
 
 
 def gravatar_profile_url(user_or_email):
-    if hasattr(user_or_email, 'email'):
+    if hasattr(user_or_email, "email"):
         email = user_or_email.email
     else:
         email = user_or_email
 
     try:
         return escape(get_gravatar_profile_url(email))
-    except:
-        return ''
+    except Exception:
+        return ""
+
 
 register.simple_tag(gravatar_url)
 register.simple_tag(gravatar)

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -1,29 +1,30 @@
 # Django settings for {{ project_name }} project.
-import os
+from pathlib import Path
 
-PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_DIR = Path(__file__).resolve().parent
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'sqlite.db',                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+    "default": {
+        # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "sqlite.db",  # Or path to database file if using sqlite3.
+        "USER": "",  # Not used with sqlite3.
+        "PASSWORD": "",  # Not used with sqlite3.
+        "HOST": "",  # Set to empty string for localhost. Not used with sqlite3.
+        "PORT": "",  # Set to empty string for default. Not used with sqlite3.
     }
 }
 
 DOCKIT_BACKENDS = {
-    'default': {
-        'ENGINE': 'dockit.backends.mongo.backend.MongoDocumentStorage',
-        'USER': 'travis',
-        'PASSWORD': 'test',
-        'DB': 'mydb_test',
-        'HOST': '127.0.0.1',
-        'PORT': 27017,
+    "default": {
+        "ENGINE": "dockit.backends.mongo.backend.MongoDocumentStorage",
+        "USER": "travis",
+        "PASSWORD": "test",
+        "DB": "mydb_test",
+        "HOST": "127.0.0.1",
+        "PORT": 27017,
     }
 }
 
@@ -35,11 +36,11 @@ DOCKIT_BACKENDS = {
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = "America/Chicago"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
@@ -51,27 +52,27 @@ USE_L10N = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
-MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')
+MEDIA_ROOT = Path(PROJECT_DIR, "media")
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
-MEDIA_URL = '/media/'
+MEDIA_URL = "/media/"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
-STATIC_ROOT = ''
+STATIC_ROOT = ""
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 # URL prefix for admin static files -- CSS, JavaScript and images.
 # Make sure to use a trailing slash.
 # Examples: "http://foo.com/static/admin/", "/static/admin/".
-ADMIN_MEDIA_PREFIX = '/static/admin/'
+ADMIN_MEDIA_PREFIX = "/static/admin/"
 
 # Additional locations of static files
 STATICFILES_DIRS = (
@@ -83,27 +84,27 @@ STATICFILES_DIRS = (
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-#    'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'example_project_test_key'
+SECRET_KEY = "example_project_test_key"
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
+    "django.template.loaders.filesystem.Loader",
+    "django.template.loaders.app_directories.Loader",
+    #     'django.template.loaders.eggs.Loader',
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 )
 
 MIDDLEWARE = MIDDLEWARE_CLASSES
@@ -117,15 +118,15 @@ TEMPLATE_DIRS = (
 )
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.sites',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django_gravatar',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django_gravatar",
     # Uncomment the next line to enable the admin:
-    'django.contrib.admin',
+    "django.contrib.admin",
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
 )
@@ -136,34 +137,31 @@ INSTALLED_APPS = (
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "mail_admins": {"level": "ERROR", "class": "django.utils.log.AdminEmailHandler"}
     },
-    'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
+    "loggers": {
+        "django.request": {
+            "handlers": ["mail_admins"],
+            "level": "ERROR",
+            "propagate": True,
         },
-    }
+    },
 }
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': TEMPLATE_DIRS,
-        'OPTIONS': {
-            'debug': TEMPLATE_DEBUG,
-            'loaders': TEMPLATE_LOADERS,
-            'context_processors': (
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            )
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": TEMPLATE_DIRS,
+        "OPTIONS": {
+            "debug": TEMPLATE_DEBUG,
+            "loaders": TEMPLATE_LOADERS,
+            "context_processors": (
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ),
         },
     },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 88

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black==22.10.0
+django==4.1.2
+flake8==5.0.4
+isort==5.10.1
+pre-commit==2.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [wheel]
 universal = 1
+
+[flake8]
+max-line-length = 88
+max-complexity = 10
+# extend-ignore = T20
+per-file-ignores =
+    django_gravatar/compat.py:F401

--- a/setup.py
+++ b/setup.py
@@ -3,27 +3,35 @@ try:
 except ImportError:
     from distutils.core import setup
 
+
+def description(file: str):
+    with open(file) as f:
+        rvalue = f.read()
+
+    return rvalue
+
+
 setup(
-    name='django-gravatar2',
-    version='1.4.4',
-    description='Essential Gravatar support for Django. Features helper'
-                ' methods, templatetags and a full test suite!',
-    long_description=open('README.rst').read(),
-    keywords='django gravatar avatar',
-    license='MIT',
-    author='Tristan Waddington',
-    author_email='tristan.waddington@gmail.com',
-    url='https://github.com/twaddington/django-gravatar',
-    packages=['django_gravatar', 'django_gravatar.templatetags'],
+    name="django-gravatar2",
+    version="2.0.0b",
+    description="Essential Gravatar support for Django. Features helper"
+    " methods, templatetags and a full test suite!",
+    long_description=description("README.rst"),
+    keywords="django gravatar avatar",
+    license="MIT",
+    author="Tristan Waddington",
+    author_email="tristan.waddington@gmail.com",
+    url="https://github.com/twaddington/django-gravatar",
+    packages=["django_gravatar", "django_gravatar.templatetags"],
     classifiers=[
-        'Development Status :: 5 - Production/Stable', # 4 Beta, 5 Production/Stable
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
-        'Framework :: Django',
-    ]
+        "Development Status :: 5 - Production/Stable",  # 4 Beta, 5 Production/Stable
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Framework :: Django",
+    ],
 )


### PR DESCRIPTION
Following [Image Requests](https://en.gravatar.com/site/implement/images/) on Gravatar's blog, I added a few new settings/options:

- GRAVATAR_AGNOSTIC_URL: defaults to '//www.gravatar.com' which allows for http or https depending on source page
- GRAVATAR_FORCE_EXTENSION: boolean that allows for file extension '.jpg' to be included if `True`. Defaults to `False`.
- GRAVATAR_DEFAULT_SECURE: added `None` option (as default) that defaults to agnostic URL

also added several formatting tools that I've become fond of:
- pre-commit
  + isort
  + black
  + flake8

a github action to automatically build and publish the package if the PyPI API token is added as a secret in the repo